### PR TITLE
Re-adds error message for too many devices

### DIFF
--- a/src/Emulator/Tabs/ConfigureTab/ConfigureTab.tsx
+++ b/src/Emulator/Tabs/ConfigureTab/ConfigureTab.tsx
@@ -1,14 +1,15 @@
-import React, { useRef, FC, useCallback, useMemo, useState } from 'react';
+import React, { useRef, FC, useCallback, useMemo } from 'react';
 
 import { DeviceType } from 'src/common/types';
 import { TopologyActions } from 'src/Emulator/useTopology';
 import { useEmulator } from 'src/Emulator/EmulatorProvider';
 
 import DeviceContainer from './DeviceContainer';
+import ErrorBox, { useErrorBox } from './ErrorBox';
+
 import './ConfigureTab.css';
 
 const MAX_DEVICES = 10;
-const FIVE_SECONDS = 5000;
 
 /**
  * Determines the number of the newly added device
@@ -40,18 +41,11 @@ const scrollDeviceContainer = (ref: React.MutableRefObject<HTMLDivElement | null
 
 const ConfigureTab: FC<{status: string}> = ({ status }) => {
   const { switches, hosts, routers, dispatch } = useEmulator();
-  const [, setShowError] = useState(false);
+  const { setError } = useErrorBox();
 
   const routerScrollRef = useRef(null);
   const switchScrollRef = useRef(null);
   const hostScrollRef = useRef(null);
-
-  const toggleErrorMessage = useCallback(() => {
-    setShowError(true);
-    setTimeout(() => {
-      setShowError(false);
-    }, FIVE_SECONDS);
-  }, []);
 
   const addDevice = useCallback((type: DeviceType) => {
     const device = type === 'router' ? routers :
@@ -63,7 +57,7 @@ const ConfigureTab: FC<{status: string}> = ({ status }) => {
 
     return (deviceLetter: string) => {
       if (device.length >= MAX_DEVICES) {
-        toggleErrorMessage();
+        setError('Max number of devices is 10!');
         return;
       }
 
@@ -78,7 +72,7 @@ const ConfigureTab: FC<{status: string}> = ({ status }) => {
         },
       });
     };
-  }, [dispatch, hosts, routers, switches, toggleErrorMessage]);
+  }, [dispatch, hosts, routers, setError, switches]);
 
   const addRouter = useMemo(() => addDevice('router'), [addDevice]);
   const addSwitch= useMemo(() => addDevice('switch'), [addDevice]);
@@ -106,6 +100,7 @@ const ConfigureTab: FC<{status: string}> = ({ status }) => {
           ref={hostScrollRef}
         />
       </div>
+      <ErrorBox />
     </div>
   );
 };

--- a/src/Emulator/Tabs/ConfigureTab/ErrorBox/ErrorBox.tsx
+++ b/src/Emulator/Tabs/ConfigureTab/ErrorBox/ErrorBox.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+
+import { useErrorBox } from './ErrorBoxProvider';
+
+import styles from './errorBox.module.css';
+
+const ErrorBox = () => {
+  const { showError, errorMessage } = useErrorBox();
+
+  return (
+    <>
+    {showError &&
+      <div className={styles.errorBox}>
+        <span className={styles.icon}>
+          <FontAwesomeIcon icon={faInfoCircle} />
+        </span>
+        <span>
+          <span className={styles.error}>
+            Error:
+          </span>
+          {` ${errorMessage}`}
+        </span>
+      </div>
+    }
+    </>
+  );
+};
+
+export default ErrorBox;

--- a/src/Emulator/Tabs/ConfigureTab/ErrorBox/ErrorBoxProvider.tsx
+++ b/src/Emulator/Tabs/ConfigureTab/ErrorBox/ErrorBoxProvider.tsx
@@ -1,0 +1,46 @@
+import React, { FC, useState, useCallback, useContext } from 'react';
+
+const ERROR_TIMEOUT = 5000; // five seconds
+
+interface ErrorBoxInterface {
+  showError: boolean;
+  errorMessage: string;
+  setError: (message: string) => any;
+}
+
+const ErrorBoxContext = React.createContext<ErrorBoxInterface>({
+  showError: false,
+  errorMessage: '',
+  setError: () => null,
+});
+
+const ErrorBoxProvider: FC = ({ children }) => {
+  const [showError, setShowError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const setError = useCallback((message: string) => {
+    setShowError(true);
+    setErrorMessage(message);
+    setTimeout(() => {
+      setShowError(false);
+      setErrorMessage('');
+    }, ERROR_TIMEOUT);
+  }, []);
+
+  return (
+    <ErrorBoxContext.Provider value={{ setError, showError, errorMessage }}>
+      {children}
+    </ErrorBoxContext.Provider>
+  );
+};
+
+export const useErrorBox = () => useContext(ErrorBoxContext);
+export function withErrorBoxProvider<T>(Component: React.ComponentType<T>) {
+  return (props: T) => (
+    <ErrorBoxProvider>
+      <Component {...props} />
+    </ErrorBoxProvider>
+  );
+}
+
+export default ErrorBoxProvider;

--- a/src/Emulator/Tabs/ConfigureTab/ErrorBox/errorBox.module.css
+++ b/src/Emulator/Tabs/ConfigureTab/ErrorBox/errorBox.module.css
@@ -1,6 +1,6 @@
 .errorBox {
   font-style: italic;
-  color: grey;
+  color: rgb(194, 194, 194);
   margin: 0.4rem auto
 }
 

--- a/src/Emulator/Tabs/ConfigureTab/ErrorBox/errorBox.module.css
+++ b/src/Emulator/Tabs/ConfigureTab/ErrorBox/errorBox.module.css
@@ -1,0 +1,13 @@
+.errorBox {
+  font-style: italic;
+  color: grey;
+  margin: 0.4rem auto
+}
+
+.icon {
+  margin: auto 0.2rem;
+}
+
+.error {
+  font-weight: bold;
+}

--- a/src/Emulator/Tabs/ConfigureTab/ErrorBox/index.ts
+++ b/src/Emulator/Tabs/ConfigureTab/ErrorBox/index.ts
@@ -1,0 +1,6 @@
+import ErrorBox from './ErrorBox';
+
+export { default as ErrorBoxProvider } from './ErrorBoxProvider';
+export * from './ErrorBoxProvider';
+
+export default ErrorBox;

--- a/src/Emulator/Tabs/ConfigureTab/index.ts
+++ b/src/Emulator/Tabs/ConfigureTab/index.ts
@@ -1,3 +1,5 @@
 import ConfigureTab from './ConfigureTab';
+import { withErrorBoxProvider } from './ErrorBox';
 export * from './ConfigureTab';
-export default ConfigureTab;
+
+export default withErrorBoxProvider(ConfigureTab);

--- a/src/Emulator/Tabs/Tabs.tsx
+++ b/src/Emulator/Tabs/Tabs.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
-import './Tabs.css';
-import ConfigureTab from './ConfigureTab/ConfigureTab';
+
+import ConfigureTab from './ConfigureTab';
 import ConsoleTab from './ConsoleTab/ConsoleTab';
 import HistoryTab from './HistoryTab/HistoryTab';
+
+import './Tabs.css';
 
 const CONSTANTS = {
   CONFIGURE: 'configure',

--- a/src/__tests__/Emulator/Tabs/ConfigureTab/ConfigureTab.test.jsx
+++ b/src/__tests__/Emulator/Tabs/ConfigureTab/ConfigureTab.test.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+
+jest.mock('src/common/api/topology/requests')
 import ConfigureTab, { getNextDeviceName, getNextNumber } from 'src/Emulator/Tabs/ConfigureTab';
+import { withEmulatorProvider } from 'src/Emulator/EmulatorProvider';
+import { render, act, fireEvent } from '@testing-library/react';
+
 
 describe('ConfigureTab helper functions', () => {
   it('should increment numbers correctly', () => {
@@ -34,5 +41,24 @@ describe('ConfigureTab', ()=> {
   it('should match previous snapshots', () => {
     const tree = renderer.create(<ConfigureTab status={'online'} />).toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('should show an error sign if there are too many devices added', () => {
+    const EmulatedConfigureTab = withEmulatorProvider(ConfigureTab);
+    const { getAllByTestId, getByText } = render(
+      <DndProvider backend={HTML5Backend}>
+        <EmulatedConfigureTab status={'show'} />
+      </DndProvider>
+    );
+
+    const plusIcon = getAllByTestId('plus-icon');
+
+    for (let i = 0; i < 12; i++) {
+      act(() => {
+        fireEvent.click(plusIcon[0]);
+      });
+    }
+
+    expect(getByText(/Max number of devices/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**[Tickets](https://trello.com/b/dYOQKJGv/reclass)** 
Trello Ticket: https://trello.com/c/SOaw6idC/323-too-many-devices-error-no-longer-shows-up
Additional Notes:
This PR fixes a bug where the "too many devices" error message was not being shown when a user tries to add another devices if there is already 10 of the current device.

**[Dependencies](https://docs.google.com/document/d/1CM6OA2nlhI3DHnHdDEgySukx_tZ_wsG-C2YgraZRvJA/edit#heading=h.czpk4cbi7z4g)**
N/A

**[Explain Impact on DB](https://docs.google.com/document/d/1CM6OA2nlhI3DHnHdDEgySukx_tZ_wsG-C2YgraZRvJA/edit#heading=h.285lgcs4z84o)**
N/A

**[Testing](https://docs.google.com/document/d/1CM6OA2nlhI3DHnHdDEgySukx_tZ_wsG-C2YgraZRvJA/edit#heading=h.rs692kr58cf8)**
Adds a unit test to make sure that the error message is not removed in the future.