### PR TITLE
docker-compose now points to production

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   backend:
-    build: https://github.com/Project-Reclass/toynet-django.git
+    build: https://github.com/Project-Reclass/toynet-django.git#PRODUCTION
     networks:
       - reclass_network
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   backend:
-    build: https://github.com/Project-Reclass/toynet-django.git#master
+    build: https://github.com/Project-Reclass/toynet-django.git#PRODUCTION
     networks:
       - reclass_network
     ports:


### PR DESCRIPTION
This PR changes the `docker-compose.*` to point to the PRODUCTION branch of the `toynet-django` repository.
This ensure that the frontend is always using the stable and deployed version of the toynet backend.

