### PR TITLE
Bug/duplicate device names

### DIFF
--- a/src/Emulator/useTopology.ts
+++ b/src/Emulator/useTopology.ts
@@ -7,7 +7,7 @@ import { SessionId, CommandRequest } from '../common/api/topology/types';
 import { useToynetSession, useModifyTopology } from '../common/api/topology';
 
 // This set is used to ensure that there are no duplicate names sent to the server to be created when there is latency
-const existingNames = new Set<string>();
+const existingDevices = new Set<string>();
 
 // This queue is used to queue up requests to the server for mininet commands. (currently not used)
 const queue: CommandRequest[] = [];
@@ -126,8 +126,8 @@ function mutationWrapper (id: SessionId, dispatch: ReducerFn<ReducerAction>, mut
         const addKey = action.type === TopologyActions.ADD_ROUTER ? 'router' :
           action.type === TopologyActions.ADD_SWITCH ? 'switch' : 'host';
         const { name } = action.payload as DeviceInterface;
-        if (!existingNames.has(name)) {
-          existingNames.add(name);
+        if (!existingDevices.has(name)) {
+          existingDevices.add(name);
           queue.push({ id, command: `add ${addKey} ${name}` });
           mutate({ id, command: `add ${addKey} ${name}` });
         }
@@ -143,7 +143,7 @@ function mutationWrapper (id: SessionId, dispatch: ReducerFn<ReducerAction>, mut
         const { to: toDelete, from: fromDelete } = action.payload as Connection;
         if (toDelete === fromDelete) {
             mutate({ id, command: `remove ${getNameFromDevice(fromDelete)} ${fromDelete}` });
-            existingNames.delete(toDelete);
+            existingDevices.delete(toDelete);
             return;
         } else {
           mutate({ id, command: `remove link ${fromDelete} ${toDelete}` });

--- a/src/Emulator/useTopology.ts
+++ b/src/Emulator/useTopology.ts
@@ -6,6 +6,12 @@ import { parseXMLTopology, ParsedXML } from '../common/topologyParser';
 import { SessionId, CommandRequest } from '../common/api/topology/types';
 import { useToynetSession, useModifyTopology } from '../common/api/topology';
 
+// This set is used to ensure that there are no duplicate names sent to the server to be created when there is latency
+const existingNames = new Set<string>();
+
+// This queue is used to queue up requests to the server for mininet commands. (currently not used)
+const queue: CommandRequest[] = [];
+
 interface Connection {
   to: string;
   from: string;
@@ -106,7 +112,6 @@ function reducer(state: ParsedXML, action: ReducerAction) {
 // we should look at a better way to handle mutations after dispatch in the future.
 type CommandFn = (cmd: CommandRequest) => any;
 function mutationWrapper (id: SessionId, dispatch: ReducerFn<ReducerAction>, mutate: CommandFn) {
-  const queue: CommandRequest[] = [];
   return (action: ReducerAction) => {
     switch (action.type) {
       case TopologyActions.ADD_CONNECTION:
@@ -121,8 +126,11 @@ function mutationWrapper (id: SessionId, dispatch: ReducerFn<ReducerAction>, mut
         const addKey = action.type === TopologyActions.ADD_ROUTER ? 'router' :
           action.type === TopologyActions.ADD_SWITCH ? 'switch' : 'host';
         const { name } = action.payload as DeviceInterface;
-        queue.push({ id, command: `add ${addKey} ${name}` });
-        mutate({ id, command: `add ${addKey} ${name}` });
+        if (!existingNames.has(name)) {
+          existingNames.add(name);
+          queue.push({ id, command: `add ${addKey} ${name}` });
+          mutate({ id, command: `add ${addKey} ${name}` });
+        }
         break;
 
       case TopologyActions.FLUSH_QUEUE:
@@ -130,10 +138,13 @@ function mutationWrapper (id: SessionId, dispatch: ReducerFn<ReducerAction>, mut
         queue.splice(0, queue.length);
         break;
 
+      // DELETE_CONNECTION handles removing devices from the server and also removing links
       case TopologyActions.DELETE_CONNECTION:
         const { to: toDelete, from: fromDelete } = action.payload as Connection;
         if (toDelete === fromDelete) {
-          mutate({ id, command: `remove ${getNameFromDevice(fromDelete)} ${fromDelete}` });
+            mutate({ id, command: `remove ${getNameFromDevice(fromDelete)} ${fromDelete}` });
+            existingNames.delete(toDelete);
+            return;
         } else {
           mutate({ id, command: `remove link ${fromDelete} ${toDelete}` });
         }


### PR DESCRIPTION
**[Tickets](https://trello.com/b/dYOQKJGv/reclass)** 
Trello Ticket: [Adding devices too quickly results in multiple devices with same name](https://trello.com/c/Hs00wnPm/381-emulator-adding-devices-too-quickly-results-in-multiple-devices-with-same-name)
Additional Notes:
Fixes issue where if you click on the plus icon above a device container it creates multiple devices with the same name. This was caused by network latency between the client and the server causing the client to get out of sync with the server and send multiple requests to create the same device.