### PR TITLE
Added BLUE deployment

### DIFF
--- a/.github/workflows/cd-blue.yml
+++ b/.github/workflows/cd-blue.yml
@@ -1,0 +1,53 @@
+name: CD-blue
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ BLUE ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-2
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: toynet-react-repo
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        cd $GITHUB_WORKSPACE
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:latest"
+    - name: Fill in the new image ID in the Amazon ECS task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition-blue.json
+        container-name: toynet-react-container
+        image: ${{ steps.build-image.outputs.image }}
+
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: toynet-react-service
+        cluster: toynet-react-cluster
+        wait-for-service-stability: true

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "toynet-react-container",
+        "image": "909056806605.dkr.ecr.us-east-2.amazonaws.com/toynet-react-repo:514e1b20ad51c6189f09a902bee0c5929ccd62fc",
+        "cpu": 0,
+        "memoryReservation": 256,
+        "portMappings": [{
+            "hostPort": 0,
+            "containerPort": 80,
+            "protocol": "tcp"
+        }],
+        "essential": true,
+        "mountPoints": [],
+        "volumesFrom": [],
+        "environment": [{
+            "name": "SERVER_URI",
+            "value": "http://${DJANGO_SERVER_URI}:8000"
+        }]
+    }
+]

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -15,7 +15,7 @@
             "volumesFrom": [],
             "environment": [{
                 "name": "SERVER_URI",
-                "value": "stage.django.projectreclass.org:8000"
+                "value": "http://stage.django.projectreclass.org:8000"
             }]
         }
     ],

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -2,7 +2,7 @@
     "containerDefinitions": [
         {
             "name": "toynet-react-container",
-            "image": "909056806605.dkr.ecr.us-east-2.amazonaws.com/toynet-react",
+            "image": "243481923718.dkr.ecr.us-east-2.amazonaws.com/toynet-react",
             "cpu": 0,
             "memoryReservation": 256,
             "portMappings": [{
@@ -19,7 +19,7 @@
             }]
         }
     ],
-    "executionRoleArn": "arn:aws:iam::909056806605:role/ecsTaskExecutionRole",
+    "executionRoleArn": "arn:aws:iam::243481923718:role/ecsTaskExecutionRole",
     "family": "toynet-react",
     "revision": 1,
     "volumes": [],

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -15,7 +15,7 @@
             "volumesFrom": [],
             "environment": [{
                 "name": "SERVER_URI",
-                "value": "http://{DJANGO_SERVER_URI}:8000"
+                "value": "internal-toynet-django-alb-1425543713.us-east-2.elb.amazonaws.com:8000"
             }]
         }
     ],

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -15,7 +15,7 @@
             "volumesFrom": [],
             "environment": [{
                 "name": "SERVER_URI",
-                "value": "internal-toynet-django-alb-1425543713.us-east-2.elb.amazonaws.com:8000"
+                "value": "stage.django.projectreclass.org:8000"
             }]
         }
     ],

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "toynet-react-container",
-        "image": "909056806605.dkr.ecr.us-east-2.amazonaws.com/toynet-react-repo:514e1b20ad51c6189f09a902bee0c5929ccd62fc",
+        "image": "909056806605.dkr.ecr.us-east-2.amazonaws.com/toynet-react-repo:latest",
         "cpu": 0,
         "memoryReservation": 256,
         "portMappings": [{

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -15,7 +15,7 @@
             "volumesFrom": [],
             "environment": [{
                 "name": "SERVER_URI",
-                "value": "http://stage.django.projectreclass.org:8000"
+                "value": "http://{DJANGO_SERVER_URI}:8000"
             }]
         }
     ],

--- a/task-definition-blue.json
+++ b/task-definition-blue.json
@@ -1,20 +1,31 @@
-[
-    {
-        "name": "toynet-react-container",
-        "image": "909056806605.dkr.ecr.us-east-2.amazonaws.com/toynet-react-repo:latest",
-        "cpu": 0,
-        "memoryReservation": 256,
-        "portMappings": [{
-            "hostPort": 0,
-            "containerPort": 80,
-            "protocol": "tcp"
-        }],
-        "essential": true,
-        "mountPoints": [],
-        "volumesFrom": [],
-        "environment": [{
-            "name": "SERVER_URI",
-            "value": "http://${DJANGO_SERVER_URI}:8000"
-        }]
-    }
-]
+{
+    "containerDefinitions": [
+        {
+            "name": "toynet-react-container",
+            "image": "909056806605.dkr.ecr.us-east-2.amazonaws.com/toynet-react",
+            "cpu": 0,
+            "memoryReservation": 256,
+            "portMappings": [{
+                "hostPort": 0,
+                "containerPort": 80,
+                "protocol": "tcp"
+            }],
+            "essential": true,
+            "mountPoints": [],
+            "volumesFrom": [],
+            "environment": [{
+                "name": "SERVER_URI",
+                "value": "http://stage.django.projectreclass.org:8000"
+            }]
+        }
+    ],
+    "executionRoleArn": "arn:aws:iam::909056806605:role/ecsTaskExecutionRole",
+    "family": "toynet-react",
+    "revision": 1,
+    "volumes": [],
+    "placementConstraints": [],
+    "requiresCompatibilities": [
+        "EC2"
+    ],
+    "memory": "256"
+}


### PR DESCRIPTION
Created a new cd file called cd-blue this file now refers to the proper region "us-east-2" and references the proper task definition "task-definition-blue.json" this should allow the terraform script to properly build the ECR by itself and allow GH Actions to push the image to the pre-existing ECR. 

This change is set to deploy on the BLUE branch and that may be the wrong change but I wanted verification before setting it to master. 

This commit should result in one failure as the ECR hasn't been built since a server side environment hasn't been created. This will be saved until a later date. 