### PR TITLE
Require all quiz questions be answered

### DIFF
--- a/src/Curriculum/Quiz/Quiz.tsx
+++ b/src/Curriculum/Quiz/Quiz.tsx
@@ -21,6 +21,8 @@ interface Params {
   quizId: string;
 }
 
+const answeredIndices = new Set();
+
 const Quiz = () => {
   const { quizId } = useParams<Params>();
   const { data, isLoading } = useQuizMeta(Number(quizId));
@@ -29,16 +31,22 @@ const Quiz = () => {
   const [isQuizSubmitted, setIsQuizSubmitted] = useState<boolean>(false);
   const [answerIsCorrect, setAnswerIsCorrect] = useState<StringMap>({});
 
+
   const handleAnsweredQuestion = (q: Question, qIndex: number, answerPicked: number) => {
     return () => {
+      answeredIndices.add(qIndex);
       answerIsCorrect[qIndex] = q.answer === answerPicked;
       setAnswerIsCorrect(answerIsCorrect);
     };
   };
 
   const submitQuiz = () => {
-    onOpen();
-    setIsQuizSubmitted(true);
+    if (data?.items.length !== answeredIndices.size) {
+      alert('You answered ' + answeredIndices.size + ' out of ' + data?.items.length + ' questions!');
+    } else {
+      onOpen();
+      setIsQuizSubmitted(true);
+    };
   };
 
   // We refresh the page so that the radio boxes are cleared.


### PR DESCRIPTION
**[Ticket](https://trello.com/c/Fj5gOY8Z/460-require-all-questions-to-be-answered-for-quiz)** 
Trello Ticket: Require all questions to be answered for quiz
Additional Notes: I created a set to store the indices of the questions that are answered. Every time an option is selected, the index of that question is added to the set. When submit is clicked, the submit function will first check if the number of questions answered doesn't equal the number of questions presented. In this case, it will display an alert. Otherwise, it will submit the quiz. 

**Testing
There are a couple cases in which I ran into potential problems. The first was once when I answered a question before the page had fully loaded, and this question's index was not added to the set. I was not able to replicate this error. The second was when I updated the code and the set was emptied while the questions still displayed as answered on the webpage. I do not anticipate this being a problem in production but I could be wrong. 
