### PR TITLE
Persist Node Locations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3503,6 +3503,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
+    "@types/localforage": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/localforage/-/localforage-0.0.34.tgz",
+      "integrity": "sha1-XjHDLdh5HsS5/z70fJy1Wy0NlDg=",
+      "dev": true,
+      "requires": {
+        "localforage": "*"
+      }
+    },
     "@types/mdast": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
@@ -9423,6 +9432,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
     "immer": {
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
@@ -12373,6 +12387,14 @@
         "type-check": "~0.3.2"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -12437,6 +12459,14 @@
             "minimist": "^1.2.0"
           }
         }
+      }
+    },
+    "localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "requires": {
+        "lie": "3.1.1"
       }
     },
     "locate-path": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "emotion": "^10.0.27",
     "emotion-theming": "^10.0.27",
     "immer": "^9.0.6",
+    "localforage": "^1.10.0",
     "path": "^0.12.7",
     "react": "^16.13.1",
     "react-contexify": "^5.0.0",
@@ -170,10 +171,13 @@
     "@testing-library/react-hooks": "^3.4.1",
     "@testing-library/user-event": "^7.2.1",
     "@types/dagre": "^0.7.44",
+    "@types/localforage": "0.0.34",
     "@types/react": "^16.9.46",
     "@types/react-dom": "^16.9.8",
     "@types/react-helmet": "^6.1.0",
     "@types/react-router-dom": "^5.1.5",
+    "@typescript-eslint/eslint-plugin": "^4.7.0",
+    "@typescript-eslint/parser": "^4.7.0",
     "awesome-typescript-loader": "^5.2.1",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jsdoc": "^3.6.7",
@@ -181,9 +185,7 @@
     "react-dnd-test-utils": "^11.1.3",
     "react-test-renderer": "^16.13.1",
     "source-map-loader": "^1.0.1",
-    "typescript": "^3.9.7",
-    "@typescript-eslint/eslint-plugin": "^4.7.0",
-    "@typescript-eslint/parser": "^4.7.0"
+    "typescript": "^3.9.7"
   },
   "proxy": "http://localhost:8080"
 }

--- a/src/Emulator/Visuals/Flow/Flow.tsx
+++ b/src/Emulator/Visuals/Flow/Flow.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button, ButtonGroup } from '@chakra-ui/core';
 import styled from '@emotion/styled';
 import localforage from 'localforage';
 import ReactFlow, {
@@ -13,15 +14,14 @@ import ReactFlow, {
   useZoomPanHelper,
 } from 'react-flow-renderer';
 
-import { createElements, getLayoutedElements, mergeElementLayouts } from './utils';
 import { DeviceInterface } from 'src/common/types';
-import { Button, ButtonGroup } from '@chakra-ui/core';
 import { SessionId } from 'src/common/api/topology/types';
 import { TopologyActions } from 'src/Emulator/useTopology';
 import { useEmulator } from 'src/Emulator/EmulatorProvider';
 import { deviceColorClasses } from 'src/Emulator/Device/deviceColors';
 
 import ClickableNode from './ClickableNode';
+import { createElements, getLayoutedElements, mergeElementLayouts } from './utils';
 
 import './overrides.css';
 
@@ -81,6 +81,10 @@ const Flow = ({ sessionId, switches, routers, hosts, isTesting = false }: Props)
 
   const { transform, fitView } = useZoomPanHelper();
 
+  /**
+   * We need to use the `sessionId` here since we do not want to use an old session's
+   * layout when the user creates a new toynet session.
+   */
   const flowSessionKey = useMemo(() => `${FLOW_STORE_KEY}-${sessionId}`, [sessionId]);
 
   const handleRestore = useCallback((newElements: Elements) => {

--- a/src/Emulator/Visuals/Flow/index.ts
+++ b/src/Emulator/Visuals/Flow/index.ts
@@ -1,2 +1,0 @@
-import Flow from './Flow';
-export default Flow;

--- a/src/Emulator/Visuals/Flow/index.tsx
+++ b/src/Emulator/Visuals/Flow/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { ReactFlowProvider } from 'react-flow-renderer';
+
+import Flow, { Props } from './Flow';
+
+
+export const WrappedFlow = (props: Props) => (
+  <ReactFlowProvider>
+    <Flow {...props} />
+  </ReactFlowProvider>
+);
+
+export default WrappedFlow;

--- a/src/Emulator/Visuals/Flow/utils.ts
+++ b/src/Emulator/Visuals/Flow/utils.ts
@@ -32,9 +32,6 @@ export const mergeElementLayouts = (sourceElements: Elements, targetElements: El
     const nodeWithPosition = targets.get(el.id)?.position;
     if (isNode(el) && nodeWithPosition) {
 
-      // unfortunately we need this little hack to pass a slightly different position
-      // to notify react flow about the change. More over we are shifting the dagre node position
-      // (anchor=center center) to the top left so it matches the react flow node anchor point (top left).
       el.position = {
         x: nodeWithPosition.x + NODE_WIDTH / BASE,
         y: nodeWithPosition.y + NODE_HEIGHT,

--- a/src/Emulator/Visuals/Flow/utils.ts
+++ b/src/Emulator/Visuals/Flow/utils.ts
@@ -1,5 +1,5 @@
 import dagre from 'dagre';
-import { Elements, FlowElement, isNode, Node, Position } from 'react-flow-renderer';
+import { Elements, isNode, Node, Position } from 'react-flow-renderer';
 import { DeviceInterface } from 'src/common/types';
 
 import { deviceColorClasses } from 'src/Emulator/Device/deviceColors';

--- a/src/Emulator/Visuals/Flow/utils.ts
+++ b/src/Emulator/Visuals/Flow/utils.ts
@@ -14,6 +14,16 @@ const LINE_WIDTH = 3;
 const NODE_WIDTH = 172;
 const NODE_HEIGHT = 36;
 
+
+/**
+ * Takes in a source elements array and a target elements array and matches the x and y from
+ * the target elements to the source elements. This is useful for matching positions from an
+ * old elements array to the new elements array.
+ *
+ * **Note**: if there are elements in the `targetElements` array that are not present in the
+ * `sourceElements` array then they will not be returned. Elements that are in `sourceElements`
+ * but not in `targetElements` will keep their x an y values.
+ */
 export const mergeElementLayouts = (sourceElements: Elements, targetElements: Elements) => {
   const targets: Map<string, Node | null> = new Map(targetElements.map(el =>
       ([el.id, isNode(el) ? el : null])));
@@ -26,7 +36,7 @@ export const mergeElementLayouts = (sourceElements: Elements, targetElements: El
       // to notify react flow about the change. More over we are shifting the dagre node position
       // (anchor=center center) to the top left so it matches the react flow node anchor point (top left).
       el.position = {
-        x: nodeWithPosition.x + NODE_WIDTH + Math.random() / BASE,
+        x: nodeWithPosition.x + NODE_WIDTH / BASE,
         y: nodeWithPosition.y + NODE_HEIGHT,
       };
     }

--- a/src/Emulator/Visuals/Flow/utils.ts
+++ b/src/Emulator/Visuals/Flow/utils.ts
@@ -1,5 +1,5 @@
 import dagre from 'dagre';
-import { Elements, isNode, Position } from 'react-flow-renderer';
+import { Elements, FlowElement, isNode, Node, Position } from 'react-flow-renderer';
 import { DeviceInterface } from 'src/common/types';
 
 import { deviceColorClasses } from 'src/Emulator/Device/deviceColors';
@@ -13,6 +13,27 @@ const BASE = 1000;
 const LINE_WIDTH = 3;
 const NODE_WIDTH = 172;
 const NODE_HEIGHT = 36;
+
+export const mergeElementLayouts = (sourceElements: Elements, targetElements: Elements) => {
+  const targets: Map<string, Node | null> = new Map(targetElements.map(el =>
+      ([el.id, isNode(el) ? el : null])));
+
+  return sourceElements.map(el => {
+    const nodeWithPosition = targets.get(el.id)?.position;
+    if (isNode(el) && nodeWithPosition) {
+
+      // unfortunately we need this little hack to pass a slightly different position
+      // to notify react flow about the change. More over we are shifting the dagre node position
+      // (anchor=center center) to the top left so it matches the react flow node anchor point (top left).
+      el.position = {
+        x: nodeWithPosition.x + NODE_WIDTH + Math.random() / BASE,
+        y: nodeWithPosition.y + NODE_HEIGHT,
+      };
+    }
+
+    return el;
+  });
+};
 
 /**
  * Takes a list of flow elements and updates the x and y of the `FlowElements`

--- a/src/Emulator/Visuals/Visuals.tsx
+++ b/src/Emulator/Visuals/Visuals.tsx
@@ -10,12 +10,13 @@ import { InnerContainer } from './styled';
 import ContextMenus from './ContextMenus';
 
 const Visuals = () => {
-  const { switches, routers, hosts } = useEmulator();
+  const { switches, routers, hosts, sessionId } = useEmulator();
   return (
     <>
     <EmulatorSection padding='0.4vh'>
       <InnerContainer>
         <Flow
+          sessionId={sessionId}
           hosts={hosts}
           routers={routers}
           switches={switches}

--- a/src/__tests__/Emulator/Visuals/Flow/Flow.test.jsx
+++ b/src/__tests__/Emulator/Visuals/Flow/Flow.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { waitFor } from '@testing-library/react';
 import { renderWithTheme } from "src/common/test-utils/renderWithTheme";
 import Flow from "src/Emulator/Visuals/Flow";
 
@@ -33,46 +33,56 @@ const hosts = [
 ];
 
 describe('Flow', () => {
-  it('should match the snapshot', () => {
+  it('should match the snapshot', async () => {
     const { container, getByText } = renderWithTheme(<Flow
       switches={switches}
       hosts={hosts}
       routers={routers}
       isTesting={true}
     />);
+
+    await waitFor(() => getByText(/r1/gi));
+
     expect(getByText(/r1/gi)).toBeInTheDocument();
     expect(getByText(/r2/gi)).toBeInTheDocument();
     expect(getByText(/s1/gi)).toBeInTheDocument();
     expect(getByText(/h1/gi)).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
-  it('should be able to render only hosts', () => {
+  it('should be able to render only hosts', async () => {
     const { container, getByText } = renderWithTheme(<Flow
       switches={[]}
       routers={[]}
       hosts={hosts}
       isTesting={true}
     />);
+    
+    await waitFor(() => getByText(/h1/gi));
     expect(getByText(/h1/gi)).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
-  it('should be able to render only switches', () => {
+  it('should be able to render only switches', async () => {
     const { container, getByText } = renderWithTheme(<Flow
       switches={switches}
       routers={[]}
       hosts={[]}
       isTesting={true}
     />);
+
+    await waitFor(() => getByText(/s1/gi));
+
     expect(getByText(/s1/gi)).toBeInTheDocument();
     expect(container).toMatchSnapshot();
   });
-  it('should be able to render only routers', () => {
+  it('should be able to render only routers', async () => {
     const { container, getByText } = renderWithTheme(<Flow
       switches={[]}
       routers={routers}
       hosts={[]}
       isTesting={true}
     />);
+
+    await waitFor(() => getByText(/r1/gi));
     expect(getByText(/r1/gi)).toBeInTheDocument();
     expect(getByText(/r2/gi)).toBeInTheDocument();
     expect(container).toMatchSnapshot();

--- a/src/__tests__/Emulator/Visuals/Flow/__snapshots__/Flow.test.jsx.snap
+++ b/src/__tests__/Emulator/Visuals/Flow/__snapshots__/Flow.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`Flow should be able to render only hosts 1`] = `
     >
       <div
         class="react-flow__nodes"
-        style="transform: translate(0px,0px) scale(1);"
+        style="transform: translate(-266px,-374px) scale(2);"
       >
         <div
           class="react-flow__node react-flow__node-default selectable"
@@ -84,7 +84,7 @@ exports[`Flow should be able to render only hosts 1`] = `
           </marker>
         </defs>
         <g
-          transform="translate(0,0) scale(1)"
+          transform="translate(-266,-374) scale(2)"
         />
       </svg>
       <div
@@ -206,12 +206,12 @@ exports[`Flow should be able to render only hosts 1`] = `
       style="width: 100%; height: 100%;"
     >
       <pattern
-        height="16"
+        height="32"
         id="pattern"
         patternUnits="userSpaceOnUse"
-        width="16"
-        x="0"
-        y="0"
+        width="32"
+        x="-10"
+        y="-22"
       >
         <circle
           cx="0.25"
@@ -242,7 +242,7 @@ exports[`Flow should be able to render only routers 1`] = `
     >
       <div
         class="react-flow__nodes"
-        style="transform: translate(0px,0px) scale(1);"
+        style="transform: translate(-266px,56px) scale(2);"
       >
         <div
           class="react-flow__node react-flow__node-default selectable"
@@ -341,7 +341,7 @@ exports[`Flow should be able to render only routers 1`] = `
           </marker>
         </defs>
         <g
-          transform="translate(0,0) scale(1)"
+          transform="translate(-266,56) scale(2)"
         />
       </svg>
       <div
@@ -463,12 +463,12 @@ exports[`Flow should be able to render only routers 1`] = `
       style="width: 100%; height: 100%;"
     >
       <pattern
-        height="16"
+        height="32"
         id="pattern"
         patternUnits="userSpaceOnUse"
-        width="16"
-        x="0"
-        y="0"
+        width="32"
+        x="-10"
+        y="24"
       >
         <circle
           cx="0.25"
@@ -499,7 +499,7 @@ exports[`Flow should be able to render only switches 1`] = `
     >
       <div
         class="react-flow__nodes"
-        style="transform: translate(0px,0px) scale(1);"
+        style="transform: translate(-266px,-202px) scale(2);"
       >
         <div
           class="react-flow__node react-flow__node-default selectable"
@@ -573,7 +573,7 @@ exports[`Flow should be able to render only switches 1`] = `
           </marker>
         </defs>
         <g
-          transform="translate(0,0) scale(1)"
+          transform="translate(-266,-202) scale(2)"
         />
       </svg>
       <div
@@ -695,12 +695,12 @@ exports[`Flow should be able to render only switches 1`] = `
       style="width: 100%; height: 100%;"
     >
       <pattern
-        height="16"
+        height="32"
         id="pattern"
         patternUnits="userSpaceOnUse"
-        width="16"
-        x="0"
-        y="0"
+        width="32"
+        x="-10"
+        y="-10"
       >
         <circle
           cx="0.25"
@@ -731,7 +731,7 @@ exports[`Flow should match the snapshot 1`] = `
     >
       <div
         class="react-flow__nodes"
-        style="transform: translate(0px,0px) scale(1);"
+        style="transform: translate(-204.5454545454545px,-72.41014799154328px) scale(1.7618040873854826);"
       >
         <div
           class="react-flow__node react-flow__node-default selectable"
@@ -880,7 +880,7 @@ exports[`Flow should match the snapshot 1`] = `
           </marker>
         </defs>
         <g
-          transform="translate(0,0) scale(1)"
+          transform="translate(-204.5454545454545,-72.41014799154328) scale(1.7618040873854826)"
         />
       </svg>
       <div
@@ -1002,12 +1002,12 @@ exports[`Flow should match the snapshot 1`] = `
       style="width: 100%; height: 100%;"
     >
       <pattern
-        height="16"
+        height="28.18886539816772"
         id="pattern"
         patternUnits="userSpaceOnUse"
-        width="16"
-        x="0"
-        y="0"
+        width="28.18886539816772"
+        x="-7.223396758280458"
+        y="-16.03241719520784"
       >
         <circle
           cx="0.25"


### PR DESCRIPTION
This PR adds the ability to restore the locations of nodes when a user either adds a new node (i.e. host, switch, router) or refreshes the page. It also will fit the view whenever a new node is added to ensure that the new node is visible to the user.