### PR TITLE
Fix bug so curriculum icon links to curriculum page

### DIFF
--- a/src/Sidebar/Sidebar.tsx
+++ b/src/Sidebar/Sidebar.tsx
@@ -124,7 +124,7 @@ const Sidebar = () => {
           <StyledNavIcon onClick={() => goToPageOnEnableHref('/blank')}>
             <Avatar src={ReclassLogo} marginBottom='1rem'/>
           </StyledNavIcon>
-          <StyledNavIcon>
+          <StyledNavIcon onClick={() => goToPageOnEnableHref('/curriculum')}>
             <StyledSvg> <Icon name='calendar' size='30px'/> </StyledSvg>
             <StyledLinkText isMenuOpen={isMenuOpen}>
               Curriculum

--- a/src/__tests__/ModuleList/Article/Article.test.tsx
+++ b/src/__tests__/ModuleList/Article/Article.test.tsx
@@ -1,0 +1,42 @@
+/*
+Copyright (C) 1992-2021 Free Software Foundation, Inc.
+
+This file is part of ToyNet React.
+
+ToyNet React is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+ToyNet React is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with ToyNet React; see the file LICENSE.  If not see
+<http://www.gnu.org/licenses/>.
+
+*/
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router-dom';
+
+import Article from 'src/Curriculum/Article';
+import { renderWithTheme } from 'src/common/test-utils/renderWithTheme';
+
+const RenderWithRouter = ({ children, moduleId, articleId }: {children: React.ReactChild, moduleId: number, articleId: number}) => (
+  <MemoryRouter initialEntries={[`/module/${moduleId}/article/${articleId}`]}>
+    <Route path="/module/:moduleId/article/:articleId">{children}</Route>
+  </MemoryRouter>
+);
+
+describe('The Article page', () => {
+  it('should render the same based on URL parameters', () => {
+    const { container } = renderWithTheme(
+      <RenderWithRouter moduleId={42} articleId={64}>
+        <Article />
+      </RenderWithRouter>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/ModuleList/Article/__snapshots__/Article.test.tsx.snap
+++ b/src/__tests__/ModuleList/Article/__snapshots__/Article.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The Article page should render the same based on URL parameters 1`] = `
+<div>
+  <div
+    class="css-u6v8er"
+  >
+    <h1
+      class="css-1nxqz3s"
+    />
+    <h2
+      class="css-14lu7sf"
+    >
+      Author: 
+    </h2>
+    <h3
+      class="css-tua7mj"
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
Checkout the [Contribution Doc](https://docs.projectreclass.org/toynet/contributing-code-to-toynet/contributing-code-to-toynet) to make sure you're contributing correctly! :)

Follow this checklist for submitting a pull request (PR):

- [x] Your ticket is a "Help Wanted" issue on GitHub for the project that you're contributing to.
- [x] Your branch is up-to-date with the main branch.
- [x] Your code follows the established code style defined in the ESLint rules.
- [x] You have included any relevant test for the code that you're contributing.
- [x] You are submitting your PR against the main branch of the repository you are contributing to from your fork.


## Description
Quick description of what this pull request does.

- If this is a bug fix, what issue is this fixing? This is fixing the bug in which clicking on the curriculum icon in the sidebar didn't redirect to the curriculum page.
- If this is a feature, describe the feature that is being added.

**Resolves Issue**: #122 
