### PR TITLE
Fixes sidebar overlap

### DIFF
--- a/src/Emulator/Emulator.tsx
+++ b/src/Emulator/Emulator.tsx
@@ -25,6 +25,7 @@ import Visuals from './Visuals';
 import Instructions from './Instructions';
 import DialogueBox from './DialogueBox';
 import ConsoleTab from './ConsoleTab';
+import styled from '@emotion/styled-base';
 
 const data = {
   'id': 1,
@@ -39,18 +40,22 @@ const data = {
   ],
 };
 
+const EmulatorGrid = styled(Grid)`
+  margin: auto;
+  max-width: 1920px;
+  height: 100vh;
+  max-height: 100vh;
+  overflow: hidden;
+  padding: 0.789rem;
+  grid-template-columns: auto 1fr;
+  @media (max-width: 2050px) {
+    margin-left: 5rem;
+  }
+`;
+
 const Emulator = () => {
   return (
-    <Grid
-      margin='auto'
-      maxWidth='1920px'
-      height='100vh'
-      maxH='100vh'
-      overflow='hidden'
-      padding={'0.789rem'}
-      gap={2}
-      gridTemplateColumns={'auto 1fr'}
-    >
+    <EmulatorGrid gap={2}>
       <Instructions panelData={data} />
       <Grid
         gridTemplateRows={'1fr 1fr'}
@@ -70,7 +75,7 @@ const Emulator = () => {
           <DialogueBox />
         </Grid>
       </Grid>
-    </Grid>
+    </EmulatorGrid>
   );
 };
 

--- a/src/__tests__/Emulator/__snapshots__/Emulator.test.tsx.snap
+++ b/src/__tests__/Emulator/__snapshots__/Emulator.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`The emulator should render and match snapshots 1`] = `
 <div>
   <div
-    class="css-1eypkte"
+    class="css-15mlykw"
   >
     <div
       class="css-8wnozy"


### PR DESCRIPTION
## Description
Fixes the overlap of the sidebar on the emulator bag. Adds a media query that sets 5rem margin left when screen is 2050 or less.

**Resolves Issue**: Fixes issue #121 
