### PR TITLE
Persistent action history

### DIFF
--- a/cypress/integration/toynet/emulator.spec.ts
+++ b/cypress/integration/toynet/emulator.spec.ts
@@ -83,4 +83,15 @@ describe('The emulator page', () => {
 
     cy.contains(/^s3$/i).should('be.visible');
   });
+  it('should allow history to persist after refresh', () => {
+    cy.visit(emulatorUrl);
+    cy.contains(/r1/i).should('be.visible');
+    cy.get('[data-testid^=emulator-add-switch]:first').click();
+    cy.contains(/^s3$/i).should('be.visible');
+    cy.contains(/created device s3/i).should('be.visible');
+    cy.reload(); // refresh the page
+
+    cy.contains(/^s3$/i).should('be.visible');
+    cy.contains(/created device s3/i).should('be.visible');
+  });
 });

--- a/src/Emulator/EmulatorProvider.tsx
+++ b/src/Emulator/EmulatorProvider.tsx
@@ -18,7 +18,8 @@ along with ToyNet React; see the file LICENSE.  If not see
 <http://www.gnu.org/licenses/>.
 
 */
-import React, { createContext, useContext, FC, useState, useCallback } from 'react';
+import React, { createContext, useContext, FC, useCallback } from 'react';
+import { useSessionStorage } from 'src/common/hooks/useSessionStorage';
 
 import { DeviceInterface, DialogueMessage } from 'src/common/types';
 import { useTopology, TopologyState, TopologyActions, Connection } from 'src/Emulator/useTopology';
@@ -36,16 +37,17 @@ const DialogueContext = createContext<DialogueInterface>({
 });
 
 const DialogueProvider: FC = ({ children }) => {
-  const [dialogueMessages, setDialogueMessages] = useState<DialogueMessage[]>([]);
+  const [dialogueMessages, setDialogueMessages] =
+    useSessionStorage<DialogueMessage[]>('history', [], value => JSON.parse(value));
 
   // Not using useCallback so we can add the same error messages repeatedly
-  const appendDialogue = (message: string, color = 'White') => {
+  const appendDialogue = useCallback((message: string, color = 'White') => {
     setDialogueMessages(dialogueMessages.concat([{message, color}]));
-  };
+  }, [dialogueMessages, setDialogueMessages]);
 
   const clearDialogue = useCallback(() => {
     setDialogueMessages([]);
-  }, []);
+  }, [setDialogueMessages]);
 
   return (
     <DialogueContext.Provider

--- a/src/common/hooks/useSessionStorage.ts
+++ b/src/common/hooks/useSessionStorage.ts
@@ -53,7 +53,7 @@ export function useSessionStorage<T>(
     if (loadedValue) {
       setSessionValue(parserRef.current ? parserRef.current(loadedValue) : loadedValue as any);
     }
-  }, [key, parser, setInitialized]);
+  }, [key, setInitialized]);
 
   const setValueInStorage = useCallback((value: T) => {
     // Since sessionStorage blocks the main thread it's probably best to


### PR DESCRIPTION
## Description
Adds persistence history to the emulator. Now when a user refreshes their page their history will still be present. This is only stored at the session level. So, when a user goes to a new tab, this history is erased.

**Resolves Issue**: closes #167 
