### PR TITLE
Updates to use topo id provided by URL

### DIFF
--- a/src/Emulator/EmulatorProvider.tsx
+++ b/src/Emulator/EmulatorProvider.tsx
@@ -19,6 +19,7 @@ along with ToyNet React; see the file LICENSE.  If not see
 
 */
 import React, { createContext, useContext, FC, useCallback } from 'react';
+import { useParams } from 'react-router';
 import { useSessionStorage } from 'src/common/hooks/useSessionStorage';
 
 import { DeviceInterface, DialogueMessage } from 'src/common/types';
@@ -69,8 +70,13 @@ const EmulatorContext = createContext<TopologyState>({
   dispatch: () => {},
 });
 
+interface Params {
+  emulatorId: string;
+}
+
 const EmulatorProvider: FC = ({ children }) => {
-  const topology = useTopology(1);
+  const { emulatorId } = useParams<Params>();
+  const topology = useTopology(Number(emulatorId));
 
   return (
     <EmulatorContext.Provider value={topology}>

--- a/src/__tests__/Emulator/EmulatorProvider.test.tsx
+++ b/src/__tests__/Emulator/EmulatorProvider.test.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 import { render, waitFor, cleanup } from '@testing-library/react';
 import { withEmulatorAndDialogueProvider, useEmulator } from 'src/Emulator/EmulatorProvider';
 import { createToynetSession, getToynetSession } from 'src/common/api/topology/requests';
+import RenderWithRouter from 'src/common/test-utils/renderWithRouter';
 
 jest.mock('src/common/api/topology/requests.ts');
 const createToynetMock = createToynetSession as jest.MockedFunction<typeof createToynetSession>;
@@ -36,12 +37,12 @@ const xml = `
 const TestingComponent = withEmulatorAndDialogueProvider(() => {
   const { switches, routers, hosts, sessionId } = useEmulator();
   return (
-    <div>
-      {sessionId > 0 && <h1>SessionId: {sessionId}</h1>}
-      {switches.map(s => <div key={s.name}>{s.name}</div>)}
-      {routers.map(s => <div key={s.name}>{s.name}</div>)}
-      {hosts.map(s => <div key={s.name}>{s.name}</div>)}
-    </div>
+      <div>
+        {sessionId > 0 && <h1>SessionId: {sessionId}</h1>}
+        {switches.map(s => <div key={s.name}>{s.name}</div>)}
+        {routers.map(s => <div key={s.name}>{s.name}</div>)}
+        {hosts.map(s => <div key={s.name}>{s.name}</div>)}
+      </div>
   );
 });
 
@@ -58,7 +59,14 @@ describe('The EmulatorProvider', () => {
 
   it('should provide switches, router, and hosts if a session key exits', async () => {
     window.sessionStorage.setItem(toynetSessionKey, '42');
-    const { getByText } = render(<TestingComponent />);
+    const { getByText } = render(
+      <RenderWithRouter
+        path='/module/:moduleId/emulator/:emulatorId'
+        initialEntries={['/module/1/emulator/1']}
+      >
+        <TestingComponent />
+      </RenderWithRouter>,
+    );
 
     await waitFor(() => getByText(/SessionId: 42/i));
 
@@ -72,7 +80,14 @@ describe('The EmulatorProvider', () => {
       toynet_session_id: 2,
     });
 
-    const { getByText } = render(<TestingComponent />);
+    const { getByText } = render(
+      <RenderWithRouter
+        path='/module/1/emulator/1'
+        initialEntries={['/module/1/emulator/1']}
+      >
+        <TestingComponent />
+      </RenderWithRouter>,
+    );
 
     await waitFor(() => getByText(/SessionId: 2/i));
 


### PR DESCRIPTION
## Description
Updates the `EmulatorProvider` to use the topology id provided by the URL instead of being hardcoded. 

**Resolves Issue**: NA
