### PR TITLE
Loaded stored devices message on load

### DIFF
--- a/src/Emulator/Visuals/Visuals.tsx
+++ b/src/Emulator/Visuals/Visuals.tsx
@@ -29,27 +29,34 @@ import LoadingAnimation from 'src/common/components/LoadingAnimation';
 import Flow from './Flow';
 import { InnerContainer } from './styled';
 import ContextMenus from './Flow/ContextMenus';
+import useStoredSessionId from 'src/common/hooks/useStoredSessionId';
+import { useParams } from 'react-router';
+
+interface Params {
+  emulatorId: string;
+}
 
 const Visuals = () => {
+  const { emulatorId } = useParams<Params>();
+  const [toynetSessionId] = useStoredSessionId(Number(emulatorId));
   const { appendDialogue, updateDialogueMessage } = useDialogue();
   const { switches, hosts, routers, sessionId, isLoading } = useEmulator();
 
-  const firstRender = useRef(true);
   const messageId = useRef('');
 
   useEffect(() => {
-    if (isLoading && sessionStorage.getItem('toynet-session-1')) {
-      messageId.current = appendDialogue('Loading topology...');
+    if (isLoading && toynetSessionId !== -1 && messageId.current === '') {
+      messageId.current = appendDialogue('Loading your saved topology...', 'grey');
     }
-  }, [isLoading, appendDialogue]);
+  }, [isLoading, appendDialogue, toynetSessionId]);
 
   useEffect(() => {
     if (!isLoading && messageId.current !== '') {
       updateDialogueMessage(messageId.current, {
-        message: 'Loaded saved topology',
+        message: 'Loaded your saved topology', color: 'yellow.300',
       });
     }
-  });
+  }, [isLoading, updateDialogueMessage]);
 
   return (
     <>

--- a/src/Emulator/Visuals/Visuals.tsx
+++ b/src/Emulator/Visuals/Visuals.tsx
@@ -18,11 +18,11 @@ along with ToyNet React; see the file LICENSE.  If not see
 <http://www.gnu.org/licenses/>.
 
 */
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Box, Heading, Text } from '@chakra-ui/core';
 import 'react-contexify/dist/ReactContexify.css';
 
-import { useEmulator } from 'src/common/providers/EmulatorProvider';
+import { useDialogue, useEmulator } from 'src/common/providers/EmulatorProvider';
 import EmulatorSection from 'src/common/components/Emulator/Section';
 import LoadingAnimation from 'src/common/components/LoadingAnimation';
 
@@ -31,7 +31,25 @@ import { InnerContainer } from './styled';
 import ContextMenus from './Flow/ContextMenus';
 
 const Visuals = () => {
+  const { appendDialogue, updateDialogueMessage } = useDialogue();
   const { switches, hosts, routers, sessionId, isLoading } = useEmulator();
+
+  const firstRender = useRef(true);
+  const messageId = useRef('');
+
+  useEffect(() => {
+    if (isLoading && sessionStorage.getItem('toynet-session-1')) {
+      messageId.current = appendDialogue('Loading topology...');
+    }
+  }, [isLoading, appendDialogue]);
+
+  useEffect(() => {
+    if (!isLoading && messageId.current !== '') {
+      updateDialogueMessage(messageId.current, {
+        message: 'Loaded saved topology',
+      });
+    }
+  });
 
   return (
     <>

--- a/src/common/api/topology/hooks.ts
+++ b/src/common/api/topology/hooks.ts
@@ -22,7 +22,6 @@ import { useCallback, useEffect } from 'react';
 import { useQuery, useMutation, queryCache } from 'react-query';
 import { devError } from 'src/common/utils';
 import { DeviceType } from 'src/common/types';
-import { useSessionStorage } from 'src/common/hooks/useSessionStorage';
 
 import {
   SessionId,
@@ -44,6 +43,7 @@ import {
   runToynetCommand,
   updateToynetSession,
 } from './requests';
+import useStoredSessionId from 'src/common/hooks/useStoredSessionId';
 
 const seenDevices = new Set();
 
@@ -129,10 +129,7 @@ export function useModifyTopology(sessionId: SessionId) {
  * session id that is stored in session storage.
  */
 export function useToynetSession(id: number) {
-  const [sessionId, setSessionId, hasInitialized] = useSessionStorage(
-    `toynet-session-${id}`, -1,
-    (value) => parseInt(value),
-  );
+  const [sessionId, setSessionId, hasInitialized] = useStoredSessionId(id);
 
   return useQuery(['toynet-session',
     { sessionId, hasInitialized }], async (_, { sessionId }) => {

--- a/src/common/hooks/useStoredSessionId.ts
+++ b/src/common/hooks/useStoredSessionId.ts
@@ -1,0 +1,26 @@
+/*
+Copyright (C) 1992-2021 Free Software Foundation, Inc.
+
+This file is part of ToyNet React.
+
+ToyNet React is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+ToyNet React is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with ToyNet React; see the file LICENSE.  If not see
+<http://www.gnu.org/licenses/>.
+
+*/
+import { useSessionStorage } from './useSessionStorage';
+
+export default function useStoredSessionId(topologyId: number) {
+  return useSessionStorage(`toynet-session-${topologyId}`, -1, (value) => parseInt(value),
+  );
+}

--- a/src/common/providers/EmulatorProvider.tsx
+++ b/src/common/providers/EmulatorProvider.tsx
@@ -18,7 +18,7 @@ along with ToyNet React; see the file LICENSE.  If not see
 <http://www.gnu.org/licenses/>.
 
 */
-import React, { createContext, useContext, FC, useCallback, useState, useEffect } from 'react';
+import React, { createContext, useContext, FC, useCallback, useEffect, useRef } from 'react';
 import { useParams } from 'react-router';
 import { useSessionStorage } from 'src/common/hooks/useSessionStorage';
 
@@ -46,28 +46,36 @@ const DialogueContext = createContext<DialogueInterface>({
 });
 
 const DialogueProvider: FC = ({ children }) => {
-  const [queue, setQueue] = useState<DialogueMessage[]>([]);
   const [dialogueMessages, setDialogueMessages, isInitialized] =
     useSessionStorage<DialogueMessage[]>('history', [],
       value => JSON.parse(value));
 
+  // We need this queue because there could be instances where a message
+  // is added to the dialogue but we haven't loaded the saved messages
+  // from session storage. If that happens, then our messages in session
+  // storage will get erased. We can use this to to store those messages
+  // added before initialization and then add it later.
+  const queue = useRef<DialogueMessage[]>([]);
+
   useEffect(() => {
     if (isInitialized) {
-      setDialogueMessages(msgs => [...msgs, ...queue]);
-      setQueue([]);
+      setDialogueMessages(msgs => [...msgs, ...queue.current]);
+      queue.current = [];
     }
-  }, [isInitialized, queue, setDialogueMessages]);
-
+  }, [isInitialized, setDialogueMessages]);
 
   // Not using useCallback so we can add the same error messages repeatedly
   const appendDialogue = useCallback((message: string, color = 'White'): DialogueMessageId => {
     const id = genUniqueId();
+
+    // if the history has not been grabbed from session storage yet, we need to
+    // store that message in the queue to be added on after initialization.
     if (!isInitialized) {
-      setQueue(prev => [...prev, { id, message, color }]);
+      queue.current.push({ id, message, color });
       return id;
     }
 
-    setDialogueMessages(prev => [...prev, {id, message, color}]);
+    setDialogueMessages(prev => [...prev, { id, message, color }]);
     return id;
   }, [isInitialized, setDialogueMessages]);
 
@@ -81,6 +89,7 @@ const DialogueProvider: FC = ({ children }) => {
   ) => {
     const updateMessage = (messages: DialogueMessage[]) => {
       const messageToUpdate = messages.findIndex(message => message.id === id);
+      console.log({ messageToUpdate, messages });
       if (messageToUpdate === -1)
         return messages;
 

--- a/src/common/providers/EmulatorProvider.tsx
+++ b/src/common/providers/EmulatorProvider.tsx
@@ -18,7 +18,7 @@ along with ToyNet React; see the file LICENSE.  If not see
 <http://www.gnu.org/licenses/>.
 
 */
-import React, { createContext, useContext, FC, useCallback } from 'react';
+import React, { createContext, useContext, FC, useCallback, useState, useEffect } from 'react';
 import { useParams } from 'react-router';
 import { useSessionStorage } from 'src/common/hooks/useSessionStorage';
 
@@ -46,16 +46,30 @@ const DialogueContext = createContext<DialogueInterface>({
 });
 
 const DialogueProvider: FC = ({ children }) => {
-  const [dialogueMessages, setDialogueMessages] =
+  const [queue, setQueue] = useState<DialogueMessage[]>([]);
+  const [dialogueMessages, setDialogueMessages, isInitialized] =
     useSessionStorage<DialogueMessage[]>('history', [],
       value => JSON.parse(value));
+
+  useEffect(() => {
+    if (isInitialized) {
+      setDialogueMessages(msgs => [...msgs, ...queue]);
+      setQueue([]);
+    }
+  }, [isInitialized, queue, setDialogueMessages]);
+
 
   // Not using useCallback so we can add the same error messages repeatedly
   const appendDialogue = useCallback((message: string, color = 'White'): DialogueMessageId => {
     const id = genUniqueId();
+    if (!isInitialized) {
+      setQueue(prev => [...prev, { id, message, color }]);
+      return id;
+    }
+
     setDialogueMessages(prev => [...prev, {id, message, color}]);
     return id;
-  }, [setDialogueMessages]);
+  }, [isInitialized, setDialogueMessages]);
 
   const clearDialogue = useCallback(() => {
     setDialogueMessages([]);

--- a/src/common/providers/EmulatorProvider.tsx
+++ b/src/common/providers/EmulatorProvider.tsx
@@ -89,7 +89,6 @@ const DialogueProvider: FC = ({ children }) => {
   ) => {
     const updateMessage = (messages: DialogueMessage[]) => {
       const messageToUpdate = messages.findIndex(message => message.id === id);
-      console.log({ messageToUpdate, messages });
       if (messageToUpdate === -1)
         return messages;
 


### PR DESCRIPTION
## Description
Adds a message when a session already exists that we are loading the saved device for the toynet session. Does not show a message when a newly created session is starting as there are no saved devices.

Also updates several bugs that were found.
- Fixes issue where value could be stale in `useSessionStorage`
- Fixes issue where a message could be overwritten if the history state is not loaded from session storage yet

**Resolves Issue**: closes #183 
