### PR TITLE
Console history per device

### DIFF
--- a/cypress/integration/toynet/emulator.spec.ts
+++ b/cypress/integration/toynet/emulator.spec.ts
@@ -165,8 +165,8 @@ describe('The emulator page', () => {
     cy.visit(emulatorUrl);
     cy.contains(/h1/i).should('be.visible');
     cy.contains(/h2/i).should('be.visible');
-    cy.get('[data-testid^="console-device-selector"]').
-      select('h1');
+    cy.get('[data-testid^="console-device-selector"]')
+      .select('h1');
     cy.get('[data-testid^="console-textarea"]').type('ping h2{enter}');
     cy.contains(/bytes of data/i).should('be.visible');
   });

--- a/cypress/integration/toynet/emulator.spec.ts
+++ b/cypress/integration/toynet/emulator.spec.ts
@@ -207,4 +207,23 @@ describe('The emulator page', () => {
       .contains(/^s3$/i).should('exist');
     cy.contains(/created switch s3/i).should('exist');
   });
+
+  it.only('should allow for different histories for different devices', () => {
+    cy.visit(emulatorUrl);
+
+    cy.get('[data-testid^="console-device-selector"]')
+      .select('h1');
+
+    cy.get('[data-testid^="console-textarea"]').type('ping h2{enter}');
+    cy.contains(/bytes of data/i).should('be.visible');
+
+    cy.get('[data-testid^="console-device-selector"]')
+      .select('h2');
+
+    cy.contains(/bytes of data/i).should('not.exist');
+
+    cy.get('[data-testid^="console-device-selector"]')
+      .select('h1');
+    cy.contains(/bytes of data/i).should('be.visible');
+  });
 });

--- a/src/Emulator/Console/ConsoleTerminal.tsx
+++ b/src/Emulator/Console/ConsoleTerminal.tsx
@@ -84,7 +84,7 @@ export default function ConsoleTerminal({
   runCommand,
 }: Props) {
   const [history, setHistory] = useSessionStorage<ToyNetCommand[]>(
-    `history-${sessionId}`, [],
+    `console-history-${sessionId}-${selectedDevice}`, [],
     (value) => JSON.parse(value),
   );
 

--- a/src/common/hooks/useSessionStorage.ts
+++ b/src/common/hooks/useSessionStorage.ts
@@ -46,6 +46,7 @@ export function useSessionStorage<T>(
   const keyRef = useRef(key);
   const parserRef = useRef(parser);
   const valueRef = useRef(sessionValue);
+  const defaultValueRef = useRef(value);
 
   useEffect(() => {
     keyRef.current = key;
@@ -60,6 +61,8 @@ export function useSessionStorage<T>(
     const loadedValue = sessionStorage.getItem(key);
     if (loadedValue) {
       setValueWithRef(parserRef.current ? parserRef.current(loadedValue) : loadedValue as any);
+    } else {
+      setValueWithRef(defaultValueRef.current);
     }
     setHasInitialized(true);
   }, [key, setValueWithRef]);


### PR DESCRIPTION
## Description
Updates the console history to be per device instead of per session. This means that when a command is ran on a selected device, that response will only be visible when that device is selected.


**Resolves Issue**: closes #240 
