### PR TITLE
Shortens the navigation text for lab

### DIFF
--- a/src/Emulator/Instructions/Instructions.tsx
+++ b/src/Emulator/Instructions/Instructions.tsx
@@ -105,6 +105,7 @@ const Instructions: FC<Props> = ({
                 variant='ghost'
                 nextText='Next'
                 prevText='Previous'
+                completeText='Complete'
                 colorScheme='whiteAlpha'
                 _hover={{ color: 'white' }}
                 moduleId={Number(moduleId)}


### PR DESCRIPTION
## Description

Previously the navigation text when completing a submodule at the lab overfilled the bottom text causing an overlap of the previous and next words - this fixes this issue by making the text say "Complete" instead of the longer "Complete Submodule".