### PR TITLE
Creates an error modal when session is not found

### DIFF
--- a/src/Emulator/Visuals/ErrorModal.tsx
+++ b/src/Emulator/Visuals/ErrorModal.tsx
@@ -1,0 +1,87 @@
+/*
+Copyright (C) 1992-2021 Free Software Foundation, Inc.
+
+This file is part of ToyNet React.
+
+ToyNet React is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 3, or (at your option) any later
+version.
+
+ToyNet React is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License
+along with ToyNet React; see the file LICENSE.  If not see
+<http://www.gnu.org/licenses/>.
+
+*/
+
+import { useEffect, useState } from 'react';
+import { Button } from '@chakra-ui/button';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from '@chakra-ui/modal';
+
+interface Props {
+  error?: unknown;
+}
+
+export default function ErrorModal({
+  error,
+}: Props) {
+  const [isError, setIsError] = useState(false);
+  const [isRestarting, setIsRestarting] = useState(false);
+
+  useEffect(() => {
+    setIsError(prevIsError => {
+      if (!prevIsError && error) {
+        return true;
+      }
+      return prevIsError;
+    });
+  }, [error]);
+
+  const handleRestart = () => {
+    setIsRestarting(true);
+
+    window.sessionStorage.clear();
+    window.location.reload();
+  };
+
+  return (
+    <Modal
+      isOpen={isError}
+      onClose={() => null}
+    >
+      <ModalOverlay />
+      <ModalContent
+        bgColor='#454950'
+        color='white'
+      >
+        <ModalHeader>Unable to find session.</ModalHeader>
+        <ModalBody>
+          We were unable to find your previous session. Please press the Restart
+          button to start a new session and continue.
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            colorScheme='red'
+            onClick={handleRestart}
+            isLoading={isRestarting}
+            loadingText='Restarting...'
+          >
+            Restart
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/Emulator/Visuals/Flow/Flow.tsx
+++ b/src/Emulator/Visuals/Flow/Flow.tsx
@@ -22,9 +22,7 @@ along with ToyNet React; see the file LICENSE.  If not see
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import styled from '@emotion/styled';
 import localforage from 'localforage';
-import {
-  useBoolean,
-} from '@chakra-ui/react';
+import { useBoolean } from '@chakra-ui/react';
 import ReactFlow, {
   Controls,
   Background,
@@ -77,8 +75,6 @@ const RightAlignedControls = styled(Controls)`
   right: 10px;
   left: unset !important;
 `;
-
-
 
 /**
  * Determines the number of the newly added device

--- a/src/Emulator/Visuals/Visuals.tsx
+++ b/src/Emulator/Visuals/Visuals.tsx
@@ -18,7 +18,7 @@ along with ToyNet React; see the file LICENSE.  If not see
 <http://www.gnu.org/licenses/>.
 
 */
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Box, Heading, Text } from '@chakra-ui/react';
 import 'react-contexify/dist/ReactContexify.css';
 
@@ -30,6 +30,7 @@ import Flow from './Flow';
 import { InnerContainer } from './styled';
 import ContextMenus from './Flow/ContextMenus';
 import useStoredSessionId from 'src/common/hooks/useStoredSessionId';
+import ErrorModal from './ErrorModal';
 
 interface Props {
   emulatorId: number;
@@ -40,7 +41,7 @@ const Visuals = ({
 }: Props) => {
   const [toynetSessionId] = useStoredSessionId(emulatorId);
   const { appendDialogue, updateDialogueMessage } = useDialogue();
-  const { switches, hosts, routers, sessionId, isLoading } = useEmulator();
+  const { switches, hosts, routers, sessionId, isLoading, error } = useEmulator();
 
   const messageId = useRef('');
 
@@ -60,27 +61,29 @@ const Visuals = ({
 
   return (
     <>
-    <EmulatorSection padding='0.4vh' data-testid='emulator-visual'>
-      <InnerContainer>
-        {isLoading ?
-          <Box position='relative' width='100%' height='100%'>
-            <LoadingAnimation>
-              <Heading size='xl' textAlign='center'>Creating Network</Heading>
-              <Text textAlign='center'>Please wait a moment while we create your new ToyNet.</Text>
-            </LoadingAnimation>
-          </Box > :
-          <Flow
-            sessionId={sessionId}
-            hosts={hosts}
-            routers={routers}
-            switches={switches}
-          />
-        }
-      </InnerContainer>
-    </EmulatorSection>
-    <ContextMenus devices={hosts} />
-    <ContextMenus devices={routers} />
-    <ContextMenus devices={switches} />
+      <EmulatorSection padding='0.4vh' data-testid='emulator-visual'>
+        <InnerContainer>
+          {isLoading ?
+            <Box position='relative' width='100%' height='100%'>
+              <LoadingAnimation>
+                <Heading size='xl' textAlign='center'>Creating Network</Heading>
+                <Text textAlign='center'>Please wait a moment while we create your new ToyNet.</Text>
+              </LoadingAnimation>
+            </Box > :
+            <Flow
+              sessionId={sessionId}
+              hosts={hosts}
+              routers={routers}
+              switches={switches}
+            />
+          }
+        </InnerContainer>
+      </EmulatorSection>
+      <ContextMenus devices={hosts} />
+      <ContextMenus devices={routers} />
+      <ContextMenus devices={switches} />
+
+      <ErrorModal error={error} />
     </>
   );
 };

--- a/src/Emulator/useTopology.ts
+++ b/src/Emulator/useTopology.ts
@@ -40,6 +40,8 @@ export interface TopologyState {
   dispatch: React.Dispatch<ReducerAction>;
   isLoading: boolean;
   sessionId: SessionId;
+
+  error?: unknown,
 }
 
 export enum TopologyActions {
@@ -133,7 +135,7 @@ const initialState: ParsedXML = {
  * Provides parsed topology state retrieved from the server.
  */
 export function useTopology(id: number) {
-  const { data, isLoading } = useToynetSession(id);
+  const { data, isLoading, error } = useToynetSession(id);
   const [state, dispatch] = useImmerReducer(reducer, initialState);
 
   useEffect(() => {
@@ -145,6 +147,7 @@ export function useTopology(id: number) {
 
   return {
     ...state,
+    error,
     isLoading,
     dispatch: dispatch,
     sessionId: data?.sessionId || -1,


### PR DESCRIPTION
## Description
Creates an error modal for when a user goes to the emulator with a
previous session but the session cannot be found on the server. Previously
what would happen is the frontend would continually try to get the
session without telling the user there is a problem. This also provides
a button which the user can press which resets the session in order
to create a new toynet session.