### PR TITLE
Module list padding

### DIFF
--- a/src/Curriculum/Module/Module.tsx
+++ b/src/Curriculum/Module/Module.tsx
@@ -50,7 +50,8 @@ const Module: FC<ModuleIntf & Props> = (
   },
 ) => {
   return (
-    <Box position='relative'>
+    <Box position='relative' pb={'2'}
+    >
       <Flex onClick={() => onClick(index)} cursor='pointer'>
         {!isLast && <Line height='100%' position='absolute' />}
         <Flex justifyContent='space-between' width='100%' pt={`${index === 0 ? '1.5rem' : ''}`}>

--- a/src/Curriculum/Module/Module.tsx
+++ b/src/Curriculum/Module/Module.tsx
@@ -50,8 +50,7 @@ const Module: FC<ModuleIntf & Props> = (
   },
 ) => {
   return (
-    <Box position='relative' pb={'2'}
-    >
+    <Box position='relative' pb={'2'}>
       <Flex onClick={() => onClick(index)} cursor='pointer'>
         {!isLast && <Line height='100%' position='absolute' />}
         <Flex justifyContent='space-between' width='100%' pt={`${index === 0 ? '1.5rem' : ''}`}>

--- a/src/Curriculum/Module/__tests__/__snapshots__/Module.test.tsx.snap
+++ b/src/Curriculum/Module/__tests__/__snapshots__/Module.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`The Module should render and match snapshots 1`] = `
 <div>
   <div
-    class="css-79elbk"
+    class="css-kbuh57"
   >
     <div
       class="css-11dqbsu"


### PR DESCRIPTION
## Description
Previously there was little to no padding between the module names
in the curriculum dashboard. This adds a padding of 2 to the module
list.
