### PR TITLE
Fix Issue #284 - Renamed "Topology Information" title in drawer

### DIFF
--- a/src/Emulator/Drawer/InfoTable/InfoTable.tsx
+++ b/src/Emulator/Drawer/InfoTable/InfoTable.tsx
@@ -47,7 +47,7 @@ export default function InfoTable({ activeName }: Props) {
 
   return (
     <Box>
-      <Heading size='md' my={3}>Topology Information</Heading>
+      <Heading size='md' my={3}>Topology Details</Heading>
       <Table>
         <tbody>
           <HostRows routers={routers} hosts={hosts} activeName={activeName} />

--- a/src/Emulator/Visuals/Flow/ContextMenus/InfoBtn.tsx
+++ b/src/Emulator/Visuals/Flow/ContextMenus/InfoBtn.tsx
@@ -47,7 +47,7 @@ export default function InfoBtn({
       alignContent='center'
       textAlign='left'
     >
-      More Info
+      More Details
     </Button>
   );
 }


### PR DESCRIPTION
## Description
Renamed the title in the drawer to be "Topology Details" instead of "Topology Information" and also changed the context menu button to be "More Details" instead of "More Info"

**Resolves Issue**: closes #284 
