### PR TITLE
Change the font of IP addresses to be monotype

### DIFF
--- a/src/Emulator/Drawer/CreateHostView.tsx
+++ b/src/Emulator/Drawer/CreateHostView.tsx
@@ -150,6 +150,7 @@ export default function CreateHostView({ nameHint }: Props) {
       <FormControl>
         <FormLabel>IP Address</FormLabel>
         <SpaceSanitizedInput
+          fontFamily='monotype'
           name={ip}
           placeholder='192.168.1.2/24'
           isDisabled={isLoading}

--- a/src/Emulator/Drawer/CreateRouterView.tsx
+++ b/src/Emulator/Drawer/CreateRouterView.tsx
@@ -145,6 +145,7 @@ export default function CreateRouterView({ nameHint }: Props) {
       <FormControl>
         <FormLabel>IP Address</FormLabel>
         <SpaceSanitizedInput
+          fontFamily='monotype'
           value={ip}
           placeholder='172.16.1.10/24'
           isDisabled={isLoading}


### PR DESCRIPTION
## Description  
Changed the font of IP address inputs to fontFamily='monotype'  for Host and Router in the emulator.   

When I ran "style:check", I am only getting the same 2 unused variables. Everything else is working.

**Resolves Issue**: closes #287.
