### PR TITLE
Connection circles size

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,5 +88,5 @@
     "start-server-and-test": "^1.14.0",
     "typescript": "^4.1.0"
   },
-  "proxy": "http://localhost:8080"
+  "proxy": "https://toynet.projectreclass.org "
 }

--- a/src/Emulator/Visuals/Flow/ClickableNode.tsx
+++ b/src/Emulator/Visuals/Flow/ClickableNode.tsx
@@ -36,7 +36,13 @@ const ColorSelectorNode: FC<NodeProps> = ({ data }) => {
 
   return (
     <>
-      <Handle type="target" position={Position.Left} />
+      <Handle type="target"
+      position={Position.Left}
+      style={{
+        width: '10px',
+        height: '10px',
+      }}
+      />
       <Flex
         data-testid='clickable_node'
         margin='auto'
@@ -50,7 +56,14 @@ const ColorSelectorNode: FC<NodeProps> = ({ data }) => {
           {data.label}
         </Text>
       </Flex>
-      <Handle type="source" position={Position.Right} />
+      <Handle
+      type="source"
+      position={Position.Right}
+      style={{
+        width: '10px',
+        height: '10px',
+      }}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Increase connection circles to be 10px   

In the ClickableNode.tsx, I updated the left and right <Handle> with 
style={{
    width: '10px',
    height: '10px',
}}

I am unable to access reactflow.dev but I found a solution at: 
https://stackoverflow.com/questions/67439157/how-to-increase-the-edge-drop-zone-using-react-flow
 
No Snapshots to update

npm run check-types
pass

npm run style:check
✖ 2 problems (0 errors, 2 warnings)

npm run style:fix
pass

npm run test
Test Suites: 30 passed, 30 total
Tests:       110 passed, 110 total
Snapshots:   19 passed, 19 total
Time:        18.478 s
Ran all test suites.

**Resolves Issue**: closes #286.
